### PR TITLE
header-check failing on ignored file

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -1,0 +1,2 @@
+ignoreFiles:
+  - '.prettierrc.js'

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  ...require('gts/.prettierrc.json')
+}


### PR DESCRIPTION
Repro of problem with the header check failing on this PR. All I did was create `.prettierrc.js` without a header and added a `.github/header-checker-lint.yml` file that should ignore it. I don't believe the pattern is the issue, because I tested with minimatch:

```node
> const minimatch = require("minimatch");
undefined
> let m = new minimatch.Minimatch(".prettierrc.js")
undefined
> m.match(".prettierrc.js")
true
```